### PR TITLE
#37 er図をソース管理できるようにした

### DIFF
--- a/back/er.drawio.svg
+++ b/back/er.drawio.svg
@@ -1,0 +1,180 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="541px" height="351px" viewBox="-0.5 -0.5 541 351" content="&lt;mxfile&gt;&lt;diagram id=&quot;SKNtCutMmLc444j5g7GL&quot; name=&quot;ページ1&quot;&gt;7Vpbj9o6EP41vB6RCxQeC7vtediVqt0jtX1aucQEax0bOWYh/fVnHNu5mS10E6Ur1RJCzHjG8fgb7G8GJtE6O30WaL+75wmmk3CanCbRzSQM5/EC3pWi0Ip4OteKVJBEq4Ja8Uh+YqOcGu2BJDhvGUrOqST7tnLDGcMb2dIhIfixbbbltP3UPUqxo3jcIOpqv5JE7rR2EX6o9f9iku7sk4P5Uo9kyBqbSPIdSvixoYpuJ9FacC71p+y0xlTtnd0X7ffpldFqYQIzeY1DqB1eED2Y2PCLctWLk4WNOD+SjCIG0mrLmXw0I1OQNztCkztU8IN6Yi7R5tlKqx0X5CfYIwpDAShgWEgDaDRtWTwqTzOnwDnYfLFhBB3VPTq1DO9QLu1qOKVon5Mf5fqUY4ZEStiKS8kzY2SCxkLi06sbF1RwQBpjnmEpCjA52ZTVHiaDK/lY50NgdbtmLiyMEpkcTKupa5jgg0HqPGqRgxqMdCGD2GS544I/4zWnXICecY0hobSjQpSkDESKt8pNbQ6BjP9o1BlJEjXzKt+jDWHpXWl2E9eaBxOkUnFw39IysXfgiGGG1Z4TJsugZyt4wTasp//MJjNY6xrkoJbhpcyFXHMGy0ekhAQDyEesgF4JLpFEP6oUvArP8DyeBsDoSvyiAeCLHfgYyrAHsBeA8xEBnDkAJkTARQNweBD7gLgcEURLJhoolrfT0x4Lwv152g/JIBwTysClMSzxQA4C5GxEIOcOjltaPsHz0Qt89O2EdDYAbh88If3979383RDShXt8qirwyYPYE8QxSenyFTojia8tesI4Ji2N3DtQcRmPYm8UR6WkkVsjOvDhJMWWuUAMRBYPmCJJOLutRzS/0QwlCBVDkZllL5AYH1U7E8TbB8D4P36PWKEGTkR+s0bw+bvaRdh5Ld1YtlIKhRUYhPitKTS8lFi7lVLRQkbF8mvqAqHzg9gYK9PCghMqxbJxC7noNdGaniMwVinKzXtpL+MchuYZX1S21gyq6szZpnTYSQO9fOPV7Kl2Jgo7E0XdiXTQzkRlSlWBX5dlLvGSKH/2dPli+/atdLlqG/Q6HFzC5anWRUR1sr8Lwhy5ZEsXqp4y98Zx1EZuePb8fJLFHnsoe0M5Jm+28/pfVQaFcFTSHLt93HwDDIOlvpc7DJpjNnNj92dqcaD+G9kXw8WYGLoXpIPf31zGmvqrWcZqbvgH69hlp7RZztpTXF3HztoTRWFnouHq2Nj9S0TFw5x888Xshd9+qky6dEIshzgh3EaXJ84XAdUJ/y5q2dhtOHvi3B/CUctYt/Z557f0225bfdb8uas1Gupq7bYfo3ioqxXE+t/D2rz+C3Z0+z8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs>
+        <clipPath id="mx-clip-4-170-132-30-0">
+            <rect x="4" y="170" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-4-200-132-30-0">
+            <rect x="4" y="200" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-4-230-132-30-0">
+            <rect x="4" y="230" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-4-260-132-30-0">
+            <rect x="4" y="260" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-4-290-132-30-0">
+            <rect x="4" y="290" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-204-170-132-30-0">
+            <rect x="204" y="170" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-204-200-132-30-0">
+            <rect x="204" y="200" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-204-230-132-30-0">
+            <rect x="204" y="230" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-204-260-132-30-0">
+            <rect x="204" y="260" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-404-170-132-30-0">
+            <rect x="404" y="170" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-404-200-132-30-0">
+            <rect x="404" y="200" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-404-230-132-30-0">
+            <rect x="404" y="230" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-404-260-132-30-0">
+            <rect x="404" y="260" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-404-290-132-30-0">
+            <rect x="404" y="290" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-404-320-132-30-0">
+            <rect x="404" y="320" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-204-30-132-30-0">
+            <rect x="204" y="30" width="132" height="30"/>
+        </clipPath>
+        <clipPath id="mx-clip-204-60-132-30-0">
+            <rect x="204" y="60" width="132" height="30"/>
+        </clipPath>
+    </defs>
+    <g>
+        <path d="M 0 170 L 0 140 L 140 140 L 140 170" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 0 170 L 0 320 L 140 320 L 140 170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 0 170 L 140 170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="69.5" y="159.5">
+                event
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-4-170-132-30-0)" font-size="12px">
+            <text x="5.5" y="189.5">
+                id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-4-200-132-30-0)" font-size="12px">
+            <text x="5.5" y="219.5">
+                name
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-4-230-132-30-0)" font-size="12px">
+            <text x="5.5" y="249.5">
+                director
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-4-260-132-30-0)" font-size="12px">
+            <text x="5.5" y="279.5">
+                start_period
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-4-290-132-30-0)" font-size="12px">
+            <text x="5.5" y="309.5">
+                end_period
+            </text>
+        </g>
+        <path d="M 200 170 L 200 140 L 340 140 L 340 170" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 200 170 L 200 290 L 340 290 L 340 170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 200 170 L 340 170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="269.5" y="159.5">
+                flight
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-204-170-132-30-0)" font-size="12px">
+            <text x="205.5" y="189.5">
+                id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-204-200-132-30-0)" font-size="12px">
+            <text x="205.5" y="219.5">
+                event_id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-204-230-132-30-0)" font-size="12px">
+            <text x="205.5" y="249.5">
+                start_time
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-204-260-132-30-0)" font-size="12px">
+            <text x="205.5" y="279.5">
+                end_time
+            </text>
+        </g>
+        <path d="M 140 185 L 160 185 Q 170 185 170 192.5 L 170 196.25 Q 170 200 170 207.5 L 170 211.25 Q 170 215 180 215 L 200 215" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 192 219 L 192 211 M 200 211 L 192 215 L 200 219" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 400 170 L 400 140 L 540 140 L 540 170" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 400 170 L 400 350 L 540 350 L 540 170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 400 170 L 540 170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="469.5" y="159.5">
+                task
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-404-170-132-30-0)" font-size="12px">
+            <text x="405.5" y="189.5">
+                id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-404-200-132-30-0)" font-size="12px">
+            <text x="405.5" y="219.5">
+                flight_id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-404-230-132-30-0)" font-size="12px">
+            <text x="405.5" y="249.5">
+                task_type_id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-404-260-132-30-0)" font-size="12px">
+            <text x="405.5" y="279.5">
+                name
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-404-290-132-30-0)" font-size="12px">
+            <text x="405.5" y="309.5">
+                scoring_period
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-404-320-132-30-0)" font-size="12px">
+            <text x="405.5" y="339.5">
+                rule
+            </text>
+        </g>
+        <path d="M 340 185 L 360 185 Q 370 185 370 192.5 L 370 196.25 Q 370 200 370 207.5 L 370 211.25 Q 370 215 380 215 L 400 215" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 392 219 L 392 211 M 400 211 L 392 215 L 400 219" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 200 30 L 200 0 L 340 0 L 340 30" fill="rgb(255, 255, 255)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 200 30 L 200 90 L 340 90 L 340 30" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 200 30 L 340 30" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" text-anchor="middle" font-size="12px">
+            <text x="269.5" y="19.5">
+                task_type
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-204-30-132-30-0)" font-size="12px">
+            <text x="205.5" y="49.5">
+                id
+            </text>
+        </g>
+        <g fill="rgb(0, 0, 0)" font-family="Helvetica" pointer-events="none" clip-path="url(#mx-clip-204-60-132-30-0)" font-size="12px">
+            <text x="205.5" y="79.5">
+                name
+            </text>
+        </g>
+        <path d="M 340 45 L 360 45 Q 370 45 370 55 L 370 135 Q 370 145 370 155 L 370 235 Q 370 245 380 245 L 400 245" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 392 249 L 392 241 M 400 241 L 392 245 L 400 249" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="none"/>
+    </g>
+</svg>


### PR DESCRIPTION
vscodeにdrawioの拡張機能をインストールし、
er図をソース管理できるようにした

編集はdraw.ioの表示で操作可能

![image](https://user-images.githubusercontent.com/59603784/185937967-f6b397eb-06e0-437b-b2a9-065395ea9e33.png)
